### PR TITLE
Add Discord timestamp formatting for launch dates

### DIFF
--- a/spacexlaunchbot/embeds/create.py
+++ b/spacexlaunchbot/embeds/create.py
@@ -1,7 +1,7 @@
 import discord
 
 from .. import config, version
-from ..utils import md_link, utc_from_time
+from ..utils import discord_timestamp_from_time, md_link, utc_from_time
 from . import colours
 from .better_embed import BetterEmbed
 
@@ -31,7 +31,7 @@ def create_schedule_embed(launch_info: dict) -> BetterEmbed:
 
     # TODO: The "launch" command can request a launch that won't have all the data and
     #  currently will cause errors (e.g. NoneType TypeError as data does not exist).
-    launch_date_str = utc_from_time(launch_info["net"])
+    launch_date_str = discord_timestamp_from_time(launch_info["net"])
 
     fields = [
         [
@@ -39,7 +39,7 @@ def create_schedule_embed(launch_info: dict) -> BetterEmbed:
             f'{launch_info["rocket"]["configuration"]["full_name"]}',
         ],
         [
-            "Launch Date (UTC)",
+            "Launch Date",
             f"{launch_date_str}",
         ],
         [
@@ -116,7 +116,7 @@ def create_launch_embed(launch_info: dict) -> BetterEmbed:
 
     """
     embed_desc = ""
-    launch_date_str = utc_from_time(launch_info["net"])
+    launch_date_str = discord_timestamp_from_time(launch_info["net"])
 
     # if (video_url := launch_info["links"]["webcast"]) is not None:
     #     embed_desc += md_link("Livestream", video_url) + "\n"
@@ -131,7 +131,7 @@ def create_launch_embed(launch_info: dict) -> BetterEmbed:
         title=f"{launch_info['name']} is launching soon!",
         description=embed_desc,
         color=colours.RED_FALCON,
-        fields=[["Launch date (UTC)", launch_date_str]],
+        fields=[["Launch Date", launch_date_str]],
     )
 
     # if (patch_url := launch_info["links"]["patch"]["small"]) is not None:

--- a/spacexlaunchbot/utils/__init__.py
+++ b/spacexlaunchbot/utils/__init__.py
@@ -1,2 +1,2 @@
-from .misc import md_link, setup_logging, sys_info, utc_from_time
+from .misc import discord_timestamp_from_time, md_link, setup_logging, sys_info, utc_from_time
 from .postgres_logger import PostgresLogger

--- a/spacexlaunchbot/utils/misc.py
+++ b/spacexlaunchbot/utils/misc.py
@@ -16,6 +16,21 @@ def utc_from_time(date_string: Union[str, None]) -> str:
     return datetime.datetime.fromisoformat(date_string).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def discord_timestamp_from_time(date_string: Union[str, None]) -> str:
+    """Converts a date string to Discord timestamp format.
+    
+    Args:
+        date_string: An ISO format date string or None.
+    
+    Returns:
+        A Discord timestamp string (<t:UNIX_TIMESTAMP:F>) or "To Be Announced".
+    """
+    if date_string is None:
+        return "To Be Announced"
+    timestamp = int(datetime.datetime.fromisoformat(date_string).timestamp())
+    return f"<t:{timestamp}:F>"
+
+
 def setup_logging() -> None:
     """Setup logging."""
     logging.basicConfig(level=config.LOG_LEVEL, format=config.LOG_FORMAT)


### PR DESCRIPTION
Introduced discord_timestamp_from_time to format launch dates for Discord embeds. Updated embed creation to use this new format and adjusted field labels for consistency.